### PR TITLE
Add "Reload with Encoding" menu items and command

### DIFF
--- a/ConvertToUTF8.py
+++ b/ConvertToUTF8.py
@@ -222,7 +222,30 @@ class EncodingSelection(threading.Thread):
 def show_selection(view):
 	EncodingSelection(view).start()
 
+class ReloadWithEncoding(threading.Thread):
+    def __init__(self, view, encoding):
+        threading.Thread.__init__(self)
+        self.view = view
+        self.encoding = encoding
+
+    def run(self):
+        sublime.set_timeout(self.reload, 0)
+
+    def reload(self):
+        init_encoding_vars(self.view, self.encoding)
+
+def reload_encoding(view, encoding):
+    ReloadWithEncoding(view, encoding).start()
+
 stamps = {}
+
+class ShowEncodingSelectionCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        show_selection(self.view)
+
+class ReloadWithEncodingCommand(sublime_plugin.TextCommand):
+    def run(self, edit, encoding):
+        reload_encoding(self.view, encoding)
 
 class PyInstructionCommand(sublime_plugin.TextCommand):
 	def run(self, edit, encoding):

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,6 @@
+[
+    {
+        "caption": "ConvertToUTF8: Reload with Encoding",
+        "command": "show_encoding_selection"
+    }
+]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -16,7 +16,21 @@
 					{ "caption": "-" },
 					{ "caption": "UTF-8", "command": "convert_to_utf8", "args": {"encoding": "UTF-8", "stamp": "0" } }
 				]
-			}
+			},
+            {
+                "caption": "Reload with Encoding",
+                "children": 
+                [
+                    { "caption": "Chinese Simplified (GBK)", "command": "reload_with_encoding", "args": {"encoding": "GBK"} },
+                    { "caption": "Chinese Traditional (BIG5)", "command": "reload_with_encoding", "args": {"encoding": "BIG5-HKSCS"} },
+                    { "caption": "Korean (EUC-KR)", "command": "reload_with_encoding", "args": {"encoding": "EUC-KR"} },
+                    { "caption": "Japanese (CP932)", "command": "reload_with_encoding", "args": {"encoding": "CP932"} },
+                    { "caption": "Japanese (Shift_JIS)", "command": "reload_with_encoding", "args": {"encoding": "Shift_JIS"} },
+                    { "caption": "Japanese (EUC-JP)", "command": "reload_with_encoding", "args": {"encoding": "EUC-JP"} },
+                    { "caption": "-" },
+                    { "caption": "UTF-8", "command": "reload_with_encoding", "args": {"encoding": "UTF-8"} }
+                ]
+            }
 		]
 	}
 ]


### PR DESCRIPTION
When ConvertToUTF8 failed to detect the encoding correctly, either
because of insufficient bytes from file or improper settings, we need
to manually specify the source file encoding. However, ConvertToUTF8
doesn't have this kind of settings/utility.

A simple test case is a GBK encoded text file with only two Chinese
characters "回家" (it may contain other ASCII characters). EUC-JP will
be detected as the source encoding and the Chinese characters are rendered
as "指社". As far as I have tested, "File" -> "Set File Encoding to"
won't help in this case.

Now, you have two choices to manually specify the source encoding when
it goes wrong:
1) "File" -> "Reload with Encoding" -> Choose the correct file encoding
2) Ctrl+Shift+P to activate the "Command Palette..." and search for
   "ConvertToUTF8: Reload with Encoding", select it and then choose
   the correct file encoding.
