### PR TITLE
Add sublime_text version selectors

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5,6 +5,7 @@
 			"details": "https://github.com/seanliang/ConvertToUTF8",
 			"releases": [
 				{
+					"sublime_text": "*",
 					"details": "https://github.com/seanliang/ConvertToUTF8/tags"
 				}
 			]
@@ -42,6 +43,7 @@
 			"details": "https://github.com/seanliang/JavaPropertiesEditor",
 			"releases": [
 				{
+					"sublime_text": "*",
 					"details": "https://github.com/seanliang/JavaPropertiesEditor/tags"
 				}
 			]


### PR DESCRIPTION
We require these now due to the confusion it caused in the past
