### PR TITLE
Prevent warning message during converting EUC-KR file

### DIFF
--- a/ConvertToUTF8.py
+++ b/ConvertToUTF8.py
@@ -24,6 +24,7 @@ SUPERSETS = {
 	'GBK': 'GB18030',
 	'BIG5': 'CP950', # CP950 is common in Taiwan
 	'CP950': 'BIG5-HKSCS' # HK official Big5 variant
+	'CP949': 'EUC-KR' # CP949 is a superset of euc-kr!
 }
 
 SETTINGS = {}


### PR DESCRIPTION
Just remove below message.

---

Errors occurred while converting **_your file_** with EUC-KR encoding.

WARNING: Continue to load this file using EUC-KR, malformed data will be
ignored.

Press "Cancel" to choose another encoding manually.
