### PR TITLE
only record command that modifies the buffer (fix #53)

### DIFF
--- a/ConvertToUTF8.py
+++ b/ConvertToUTF8.py
@@ -724,6 +724,8 @@ class ConvertToUTF8Listener(sublime_plugin.EventListener):
 		if command == NONE_COMMAND:
 			if command1[0] == 'convert_to_utf8':
 				view.run_command('redo')
+			else:
+				view.set_scratch(True)
 		elif command[0] == 'convert_to_utf8':
 			if file_name in stamps:
 				if stamps[file_name] == command[1].get('stamp'):

--- a/ConvertToUTF8.py
+++ b/ConvertToUTF8.py
@@ -624,11 +624,11 @@ class ConvertToUTF8Listener(sublime_plugin.EventListener):
 		encoding = view.encoding()
 		if encoding == 'Hexadecimal' or encoding.endswith(' BOM'):
 			return
-		
+
 		#if sublime text already load right, no need to check the file's encoding
 		if encoding not in ('Undefined', view.settings().get('fallback_encoding')):
 			return
-		
+
 		file_name = view.file_name()
 		if not file_name:
 			return
@@ -719,8 +719,8 @@ class ConvertToUTF8Listener(sublime_plugin.EventListener):
 			return
 		if self.check_clones(view):
 			return
-		command = view.command_history(0)
-		command1 = view.command_history(1)
+		command = view.command_history(0, True)
+		command1 = view.command_history(1, True)
 		if command == NONE_COMMAND:
 			if command1[0] == 'convert_to_utf8':
 				view.run_command('redo')

--- a/ConvertToUTF8.py
+++ b/ConvertToUTF8.py
@@ -188,6 +188,7 @@ def setup_views():
 		for view in win.views():
 			if not get_setting(view, 'convert_on_load'):
 				break
+			view.settings().set('is_init_dirty_state', view.is_dirty())
 			if view.is_dirty() or view.settings().get('origin_encoding'):
 				show_encoding_status(view)
 				continue
@@ -725,7 +726,7 @@ class ConvertToUTF8Listener(sublime_plugin.EventListener):
 			if command1[0] == 'convert_to_utf8':
 				view.run_command('redo')
 			else:
-				view.set_scratch(True)
+				view.set_scratch(not view.settings().get('is_init_dirty_state', False))
 		elif command[0] == 'convert_to_utf8':
 			if file_name in stamps:
 				if stamps[file_name] == command[1].get('stamp'):


### PR DESCRIPTION
See API reference for the meaning of the second argument of
`command_history`: https://www.sublimetext.com/docs/3/api_reference.html

This fixes #53, to reproduce:
1. Open a GBK encoded file.
2. Move the cursor down
3. Insert a char
4. Undo

After these steps, the buffer will be in a dirty status, which is not
desired.

When inspecting the content of `command` and `comman1` in the
forementioned steps, One can see the following logs:

```
command: ('insert', {'characters': 'j'}, 1); command1: ('', None, 0)
command: ('move', {'forward': True, 'by': 'lines'}, 2); command1: ('insert', {'characters': 'j'}, 1)
command: ('', None, 0); command1: ('convert_to_utf8', {'stamp': '1461504893.485919', 'detect_on_fail': False}, 1)
command: ('convert_to_utf8', {'stamp': '1461504893.485919', 'detect_on_fail': False}, 1); command1: ('', None, 1)
  1461504893.485919 {'stamp': '1461504893.485919', 'detect_on_fail': False}
```

So the problem seems to be that `move` command undesirably appears in the command history.


Another newer commit fix clean state when undoing in restarted view. See the commit message for details.